### PR TITLE
Update Windows App SDK version to 1.1.5

### DIFF
--- a/Changelog.xml
+++ b/Changelog.xml
@@ -4,4 +4,5 @@
 	<Item version="1.0.2" detail="First WinUI app revamp preview" />
 	<Item version="1.0.4" detail="Automatic updates now available" />
 	<Item version="1.0.5" detail="Upgraded Windows App SDK to 1.1.3, basic reporting functionality implemented" />
+	<Item version="1.0.6" detail="Upgraded Windows App SDK to 1.1.5, added a few basic inbox scripts" />
 </Changelog>

--- a/ITATKWinUI.csproj
+++ b/ITATKWinUI.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="CsvHelper" Version="28.0.1" />
     <PackageReference Include="microsoft.powershell.sdk" Version="7.2.5" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.5" />
     <PackageReference Include="PInvoke.User32" Version="0.7.124" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Eventually, explore cross-platform support for macOS and Linux.
 
 **Prerequisites (In-Progress):**
-- At a minimum if you just want to run the built app you will need the proper [Windows App Runtime Redist](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/downloads#current-releases) (Currently: Version 1.1.3) installed, this project is primarily targeted towards x64 but please feel free to open an Issue or PR for other platforms if you find they aren't working.
+- At a minimum if you just want to run the built app you will need the proper [Windows App Runtime Redist](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/downloads#current-releases) (Currently: Version 1.1.5) installed, this project is primarily targeted towards x64 but please feel free to open an Issue or PR for other platforms if you find they aren't working.
     - For development - environmental requirements can be found [here](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/create-your-first-winui3-app#unpackaged-create-a-new-project-for-an-unpackaged-c-or-c-winui-3-desktop-app)
     - Ensure you install the proper [C# Windows App SDK Templates](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=vs-2022-17-1-a%2Cvs-2022-17-1-b#required-workloads-and-components)
     - Currently, this project is intended to be unpackaged if you are running the .sln from Visual Studio


### PR DESCRIPTION
Updated Windows App SDK version to 1.1.5. 

Eventually we will add in better handling for these dependencies, but for now the ReadMe has been updated to reflect this.